### PR TITLE
Fixed sensitive_post_parameter error on password change form

### DIFF
--- a/django_libtech_emailuser.egg-info/PKG-INFO
+++ b/django_libtech_emailuser.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 1.1
 Name: django-libtech-emailuser
-Version: 0.2
+Version: 0.2.1
 Summary: Use emailaddress as username in Django +1.5
 Home-page: https://github.com/Liberationtech/django-libtech-emailuser
 Author: Oivvio Polite

--- a/emailuser/admin.py
+++ b/emailuser/admin.py
@@ -19,7 +19,7 @@ from emailuser.forms import EmailUserCreationForm
 from emailuser.models import EmailUser
 
 csrf_protect_m = method_decorator(csrf_protect)
-
+sensitive_post_parameters_m = method_decorator(sensitive_post_parameters())
 
 class EmailUserAdmin(admin.ModelAdmin):
     add_form_template = 'admin/auth/user/add_form.html'
@@ -72,7 +72,7 @@ class EmailUserAdmin(admin.ModelAdmin):
                          self.admin_site.admin_view(self.user_change_password))
                         ) + super(EmailUserAdmin, self).get_urls()
 
-    @sensitive_post_parameters()
+    @sensitive_post_parameters_m
     @csrf_protect_m
     @transaction.commit_on_success
     def add_view(self, request, form_url='', extra_context=None):
@@ -103,7 +103,7 @@ class EmailUserAdmin(admin.ModelAdmin):
         return super(EmailUserAdmin, self).add_view(request, form_url,
                                                     extra_context)
 
-    @sensitive_post_parameters()
+    @sensitive_post_parameters_m
     def user_change_password(self, request, id, form_url=''):
         if not self.has_change_permission(request):
             raise PermissionDenied


### PR DESCRIPTION
sensitive_post_parameters has to be a method_decorator, just like csrf_protect. Otherwise, the password change form returns an error.

Verified on Django 1.5.4 and 1.6 with DEBUG=True
