### PR TITLE
Fix TransactionManagementError while adding a user

### DIFF
--- a/emailuser/admin.py
+++ b/emailuser/admin.py
@@ -74,7 +74,7 @@ class EmailUserAdmin(admin.ModelAdmin):
 
     @sensitive_post_parameters_m
     @csrf_protect_m
-    @transaction.commit_on_success
+    @transaction.atomic
     def add_view(self, request, form_url='', extra_context=None):
         # It's an error for a user to have add permission but NOT change
         # permission for users. If we allowed such users to add users, they


### PR DESCRIPTION
Fixes 'TransactionManagementError at /admin/emailuser/emailuser/add/'

copied from 
https://github.com/django/django/blob/master/django/contrib/auth/admin.py#L93
