### PR TITLE
Fix AttributeError on Django 1.8

### DIFF
--- a/emailuser/admin.py
+++ b/emailuser/admin.py
@@ -107,7 +107,7 @@ class EmailUserAdmin(admin.ModelAdmin):
     def user_change_password(self, request, id, form_url=''):
         if not self.has_change_permission(request):
             raise PermissionDenied
-        user = get_object_or_404(self.queryset(request), pk=id)
+        user = get_object_or_404(self.get_queryset(request), pk=id)
         if request.method == 'POST':
             form = self.change_password_form(user, request.POST)
             if form.is_valid():


### PR DESCRIPTION
Similar to [the fix by django-guardian](https://github.com/django-guardian/django-guardian/pull/336/files), Django 1.8 changes `.queryset` to `.get_queryset`. See issue for compatibility lists and test results.
